### PR TITLE
Harden shutdown

### DIFF
--- a/btsoot.go
+++ b/btsoot.go
@@ -47,28 +47,5 @@ func main() {
 	signal.Notify(signals, syscall.SIGINT)
 	<-signals
 	fmt.Println("Exiting. Please wait...")
-
-	/*
-		for k, v := range ProcessList {
-			fmt.Printf("Sending stop (%x) to THREADID=%d\n", StopCode, k)
-			v.Channel <- StopCode
-		}
-
-		for len(ProcessList) != 0 {
-			for k, v := range ProcessList {
-				select {
-				case callback := <-v.Channel:
-					if callback == ConfirmCode {
-						fmt.Printf("THREADID=%d: Confirmation (%x)\n", k, ConfirmCode)
-						delete(ProcessList, k)
-					} else if callback == ErrorCode {
-						fmt.Println("THREADID=%d: Error (%x)\n", k, ErrorCode)
-					}
-				default:
-					// NOTE: Thread did not respond, wait for the next flyby
-				}
-			}
-		}
-	*/
 	KillAll(ProcessList)
 }

--- a/btsoot.go
+++ b/btsoot.go
@@ -46,6 +46,6 @@ func main() {
 
 	signal.Notify(signals, syscall.SIGINT)
 	<-signals
-	fmt.Println("Exiting. Please wait...")
+	log.Println("Exiting. Please wait...")
 	KillAll(ProcessList)
 }

--- a/btsoot.go
+++ b/btsoot.go
@@ -48,23 +48,27 @@ func main() {
 	<-signals
 	fmt.Println("Exiting. Please wait...")
 
-	for k, v := range ProcessList {
-		fmt.Printf("Sending stop (%x) to THREADID=%d\n", StopCode, k)
-		v.Channel <- StopCode
-	}
-	for len(ProcessList) != 0 {
+	/*
 		for k, v := range ProcessList {
-			select {
-			case callback := <-v.Channel:
-				if callback == ConfirmCode {
-					fmt.Printf("THREADID=%d: Confirmation (%x)\n", k, ConfirmCode)
-					delete(ProcessList, k)
-				} else if callback == ErrorCode {
-					fmt.Println("THREADID=%d: Error (%x)\n", k, ErrorCode)
+			fmt.Printf("Sending stop (%x) to THREADID=%d\n", StopCode, k)
+			v.Channel <- StopCode
+		}
+
+		for len(ProcessList) != 0 {
+			for k, v := range ProcessList {
+				select {
+				case callback := <-v.Channel:
+					if callback == ConfirmCode {
+						fmt.Printf("THREADID=%d: Confirmation (%x)\n", k, ConfirmCode)
+						delete(ProcessList, k)
+					} else if callback == ErrorCode {
+						fmt.Println("THREADID=%d: Error (%x)\n", k, ErrorCode)
+					}
+				default:
+					// NOTE: Thread did not respond, wait for the next flyby
 				}
-			default:
-				// NOTE: Thread did not respond, wait for the next flyby
 			}
 		}
-	}
+	*/
+	KillAll(ProcessList)
 }

--- a/internalprocs.go
+++ b/internalprocs.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"fmt"
+	"sync"
+)
+
 const (
 	UpdateThreadID    = 0
 	ScanThreadID      = 1
@@ -9,6 +14,12 @@ const (
 	ConfirmCode = 1001
 	ErrorCode   = 1002
 )
+
+type Process struct {
+	Channel      chan int
+	Level        int
+	Subprocesses map[int]Process
+}
 
 func CreateMasterProcessList() map[int]Process {
 	pmap := make(map[int]Process)
@@ -29,20 +40,21 @@ func CreateMasterProcessList() map[int]Process {
 	return pmap
 }
 
-func ListProcessList() {
-	return
+func (p Process) Kill(wg *sync.WaitGroup) {
+	p.Channel <- StopCode
+	callback := <-p.Channel
+	if callback == ErrorCode {
+		fmt.Println("Error (%x)\nYou may have to kill btsoot. Shutdown is now unsafe.", ErrorCode)
+	}
+	wg.Done()
 }
 
-func (p Process) AddProcessToList() {
-	return
-}
-
-func (p Process) Kill() {
-	return
-}
-
-type Process struct {
-	Channel      chan int
-	Level        int
-	Subprocesses map[int]Process
+func KillAll(m map[int]Process) {
+	var wg sync.WaitGroup
+	for _, v := range m {
+		wg.Add(1)
+		go v.Kill(&wg)
+	}
+	wg.Wait()
+	fmt.Println("Everything is shutted down.")
 }


### PR DESCRIPTION
This unblocks the stop code, which will help to minimize damage to data
in case on of the threads blocks. Now, if one thread stalls, the program
shuts everything else down, and then repeatedly tries to shut this
thread down. If its not working, the user can kill the program without
loosing all other threads behind this.